### PR TITLE
Pad leaves

### DIFF
--- a/DB/migrations/20190525210231_create_account.js
+++ b/DB/migrations/20190525210231_create_account.js
@@ -7,6 +7,7 @@ exports.up = function (knex, Promise) {
     t.integer('balance').notNullable()
     t.integer('nonce').notNullable()
     t.integer('tokenType').notNullable()
+    t.unique('pubkeyX')
   })
 };
 

--- a/src/snark_utils/MiMCMerkle.js
+++ b/src/snark_utils/MiMCMerkle.js
@@ -78,7 +78,6 @@ module.exports = {
     },
 
     pairwiseHash: function (array) {
-        // console.log("generating pairwise hash", array.length)
         if (array.length % 2 == 0) {
             var arrayHash = []
             for (var i = 0; i < array.length; i = i + 2) {

--- a/src/snark_utils/update.js
+++ b/src/snark_utils/update.js
@@ -9,6 +9,15 @@ const {stringifyBigInts, unstringifyBigInts} = require('./stringifybigint.js')
 const bigInt = require('snarkjs').bigInt
 
 const NONCE_MAX_VALUE = 100;
+const ZERO_HASH = '\x00'.repeat(32);
+
+function pad(array, max_length) {
+    if (array.length > max_length) {
+        throw new Error(`Length of input array ${array.length} is longer than max_length ${max_length}`);
+    }
+    const zero_hash_array = new Array(max_length - array.length).fill(ZERO_HASH);
+    return array.concat(zero_hash_array)
+}
 
 module.exports = {
 
@@ -52,7 +61,7 @@ module.exports = {
         const txArray = txLeaf.generateTxLeafArray(
             from_x, from_y, to_x, to_y, amounts, tx_token_types
         )
-        const txLeafHashes = txLeaf.hashTxLeafArray(txArray)
+        const txLeafHashes = pad(txLeaf.hashTxLeafArray(txArray), 2 ** tx_depth)
         const txTree = merkle.treeFromLeafArray(txLeafHashes)
         const txRoot = merkle.rootFromLeafArray(txLeafHashes)
         const txProofs = merkle.generateMerkleProofArray(txTree, txLeafHashes)


### PR DESCRIPTION
### What's wrong

- The number of leaves in the transaction tree is not padded to the 2**depth, so when building the hash tree the pairwiseHash function complains about 'array must have even number of elements'.
- The table of account has no unique key defined, so it treats the same user as a new account. And since in the fixture data only 4 accounts defined, as the new rows added to the table the number of leaves in the balance array is also incorrect and thus raise errors.

### How can it be fixed

- For tx tree, pad zero hashes to the leaves
- For balance tree, define a unique key.